### PR TITLE
fix: terraform validate needs no state

### DIFF
--- a/.github/workflows/lint-terraform.yml
+++ b/.github/workflows/lint-terraform.yml
@@ -25,7 +25,7 @@ jobs:
         uses: docker://hashicorp/terraform:light
         with:
           entrypoint: terraform
-          args: init
+          args: init -backend=false
 
       - name: Terraform validate
         uses: docker://hashicorp/terraform:light


### PR DESCRIPTION
Use a false backend on init via command line args. This overrides any backend set within modules and enables linting without touching terraform state.